### PR TITLE
Add notification status indicator and dynamic page title

### DIFF
--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -233,6 +233,8 @@ function save() {
       mode: mode.value,
       cycle: cycle.value,
       remaining: remaining.value,
+      timerStartTime: timerStartTime.value,
+      totalPausedTime: totalPausedTime.value,
     })
   )
 }

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -251,6 +251,10 @@ onMounted(() => {
   load()
   if (running.value) start()
   requestNotificationPermission()
+  // Atualizar estado da permissão
+  if ('Notification' in window) {
+    notificationPermission.value = Notification.permission
+  }
 })
 
 onBeforeUnmount(() => stopTicker())

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -127,6 +127,7 @@ const running = ref(false)
 const mode = ref<'work' | 'short' | 'long'>('work')
 const cycle = ref(1)
 const remaining = ref(DUR.work)
+const notificationPermission = ref(Notification.permission)
 let ticker: number | null = null
 
 // Audio for end sound

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -408,6 +408,21 @@ const notificationIcon = computed(() =>
 const notificationColor = computed(() =>
   notificationPermission.value === 'granted' ? 'success' : 'warning'
 )
+
+// Update page title with timer
+function updatePageTitle() {
+  if (running.value) {
+    const modeText = mode.value === 'work'
+      ? '🍅 Foco'
+      : mode.value === 'short'
+        ? '☕ Pausa Curta'
+        : '🛋️ Pausa Longa'
+
+    document.title = `${timeText.value} - ${modeText} | TrueDo`
+  } else {
+    document.title = 'TrueDo - Produtividade Inteligente'
+  }
+}
 </script>
 
 <style scoped>

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -294,21 +294,31 @@ function start() {
   stopTicker()
   ensureSegmentStart()
   ensureAudio()
+
+  const now = Date.now()
+
   if (pauseStart.value) {
     // closing a pause window
+    const pauseDuration = now - pauseStart.value.getTime()
+    totalPausedTime.value += pauseDuration
+
     pauses.value.push({
       startedAt: pauseStart.value.toISOString(),
       endedAt: new Date().toISOString(),
     })
     pauseStart.value = null
   }
+
+  if (!timerStartTime.value) {
+    // Starting fresh timer
+    timerStartTime.value = now
+    totalPausedTime.value = 0
+  }
+
   running.value = true
   ticker = window.setInterval(() => {
-    remaining.value = Math.max(0, remaining.value - 1)
-    if (remaining.value === 0) {
-      completeSegment()
-    }
-  }, 1000)
+    calculateRemainingTime()
+  }, 100) // Usar 100ms para maior precisão
 }
 function stopTicker() {
   if (ticker) {

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -168,6 +168,32 @@ function playEndSound() {
   }
 }
 
+// Notification support
+function requestNotificationPermission() {
+  if ('Notification' in window && Notification.permission === 'default') {
+    Notification.requestPermission()
+  }
+}
+
+function showNotification() {
+  if ('Notification' in window && Notification.permission === 'granted') {
+    const title = mode.value === 'work'
+      ? '🍅 Pomodoro Concluído!'
+      : '⏰ Pausa Finalizada!'
+
+    const message = mode.value === 'work'
+      ? `Foco de 25 minutos concluído! Hora da pausa.`
+      : `Pausa finalizada! Hora de voltar ao trabalho.`
+
+    new Notification(title, {
+      body: message,
+      icon: '/favicon.svg',
+      requireInteraction: true,
+      tag: 'pomodoro-timer'
+    })
+  }
+}
+
 // Segment tracking for persistence
 const segmentStart = ref<Date | null>(null)
 const pauseStart = ref<Date | null>(null)

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -296,6 +296,7 @@ async function persistCurrentSegment() {
 async function completeSegment() {
   pause()
   playEndSound()
+  showNotification()
   await persistCurrentSegment()
   // prepare next segment
   segmentStart.value = null

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -248,6 +248,8 @@ function load() {
     mode.value = s.mode || 'work'
     cycle.value = s.cycle || 1
     remaining.value = typeof s.remaining === 'number' ? s.remaining : DUR.work
+    timerStartTime.value = s.timerStartTime || null
+    totalPausedTime.value = s.totalPausedTime || 0
   } catch {}
 }
 

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -381,6 +381,8 @@ function stop() {
   segmentStart.value = null
   pauses.value = []
   pauseStart.value = null
+  timerStartTime.value = null
+  totalPausedTime.value = 0
   remaining.value =
     mode.value === 'work'
       ? DUR.work

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -229,6 +229,7 @@ function load() {
 onMounted(() => {
   load()
   if (running.value) start()
+  requestNotificationPermission()
 })
 
 onBeforeUnmount(() => stopTicker())

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -276,6 +276,20 @@ function ensureSegmentStart() {
   if (!segmentStart.value) segmentStart.value = new Date()
 }
 
+function calculateRemainingTime() {
+  if (!timerStartTime.value) return
+
+  const now = Date.now()
+  const elapsedTime = Math.floor((now - timerStartTime.value - totalPausedTime.value) / 1000)
+  const duration = mode.value === 'work' ? DUR.work : mode.value === 'short' ? DUR.short : DUR.long
+
+  remaining.value = Math.max(0, duration - elapsedTime)
+
+  if (remaining.value === 0 && running.value) {
+    completeSegment()
+  }
+}
+
 function start() {
   stopTicker()
   ensureSegmentStart()

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -260,6 +260,7 @@ onMounted(() => {
 onBeforeUnmount(() => stopTicker())
 
 watch([expanded, running, mode, cycle, remaining], save, { deep: true })
+watch([remaining, running, mode], updatePageTitle)
 
 function ensureSegmentStart() {
   if (!segmentStart.value) segmentStart.value = new Date()

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -89,8 +89,16 @@
           variant="elevated"
           >{{ pillShort }}</v-chip
         >
-        <div class="timer-mono text-subtitle-1 mr-3" :class="textColor">
-          {{ timeText }}
+        <div class="d-flex align-center mr-3">
+          <div class="timer-mono text-subtitle-1 mr-1" :class="textColor">
+            {{ timeText }}
+          </div>
+          <v-icon
+            :icon="notificationIcon"
+            :color="notificationColor"
+            size="x-small"
+            :title="notificationPermission === 'granted' ? 'Notificações ativadas' : 'Notificações desativadas'"
+          />
         </div>
         <v-progress-linear
           bg-color="surface"

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -273,7 +273,7 @@ onBeforeUnmount(() => {
   document.title = 'TrueDo - Produtividade Inteligente'
 })
 
-watch([expanded, running, mode, cycle, remaining], save, { deep: true })
+watch([expanded, running, mode, cycle, remaining, timerStartTime, totalPausedTime], save, { deep: true })
 watch([remaining, running, mode], updatePageTitle)
 
 function ensureSegmentStart() {

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -300,6 +300,7 @@ function pause() {
   if (!pauseStart.value) pauseStart.value = new Date()
   running.value = false
   stopTicker()
+  updatePageTitle()
 }
 function toggleRun() {
   running.value ? pause() : start()

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -381,6 +381,13 @@ const barColor = computed(() => 'surface')
 const textColor = computed(() =>
   mode.value === 'work' ? 'text-primary' : 'text-secondary'
 )
+
+const notificationIcon = computed(() =>
+  notificationPermission.value === 'granted' ? 'mdi-bell' : 'mdi-bell-off'
+)
+const notificationColor = computed(() =>
+  notificationPermission.value === 'granted' ? 'success' : 'warning'
+)
 </script>
 
 <style scoped>

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -403,6 +403,10 @@ async function skipSegment() {
 }
 
 function addMinute(delta: number) {
+  if (timerStartTime.value) {
+    // Ajustar o tempo de início para refletir a mudança
+    timerStartTime.value -= delta * 60 * 1000
+  }
   remaining.value = Math.max(0, remaining.value + delta * 60)
 }
 

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -363,6 +363,8 @@ async function completeSegment() {
   segmentStart.value = null
   pauses.value = []
   pauseStart.value = null
+  timerStartTime.value = null
+  totalPausedTime.value = 0
 
   if (mode.value === 'work') {
     cycle.value = (cycle.value % 4) + 1

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -342,6 +342,7 @@ async function completeSegment() {
     mode.value = 'work'
     remaining.value = DUR.work
   }
+  updatePageTitle()
 }
 
 function stop() {
@@ -420,7 +421,7 @@ const notificationColor = computed(() =>
 function updatePageTitle() {
   if (running.value) {
     const modeText = mode.value === 'work'
-      ? '🍅 Foco'
+      ? '���� Foco'
       : mode.value === 'short'
         ? '☕ Pausa Curta'
         : '🛋️ Pausa Longa'

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -356,6 +356,7 @@ function stop() {
       : mode.value === 'short'
         ? DUR.short
         : DUR.long
+  updatePageTitle()
 }
 
 async function skipSegment() {

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -172,7 +172,11 @@ function playEndSound() {
 // Notification support
 function requestNotificationPermission() {
   if ('Notification' in window && Notification.permission === 'default') {
-    Notification.requestPermission()
+    Notification.requestPermission().then((permission) => {
+      notificationPermission.value = permission
+    })
+  } else {
+    notificationPermission.value = Notification.permission
   }
 }
 

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -255,9 +255,13 @@ onMounted(() => {
   if ('Notification' in window) {
     notificationPermission.value = Notification.permission
   }
+  updatePageTitle()
 })
 
-onBeforeUnmount(() => stopTicker())
+onBeforeUnmount(() => {
+  stopTicker()
+  document.title = 'TrueDo - Produtividade Inteligente'
+})
 
 watch([expanded, running, mode, cycle, remaining], save, { deep: true })
 watch([remaining, running, mode], updatePageTitle)

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -255,7 +255,11 @@ function load() {
 
 onMounted(() => {
   load()
-  if (running.value) start()
+  // Calcular tempo correto se o timer estava rodando
+  if (running.value && timerStartTime.value) {
+    calculateRemainingTime()
+    start()
+  }
   requestNotificationPermission()
   // Atualizar estado da permissão
   if ('Notification' in window) {

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -16,8 +16,16 @@
           variant="elevated"
           >{{ pillText }}</v-chip
         >
-        <div class="timer-mono text-h5 mr-6" :class="textColor">
-          {{ timeText }}
+        <div class="d-flex align-center mr-6">
+          <div class="timer-mono text-h5 mr-2" :class="textColor">
+            {{ timeText }}
+          </div>
+          <v-icon
+            :icon="notificationIcon"
+            :color="notificationColor"
+            size="small"
+            :title="notificationPermission === 'granted' ? 'Notificações ativadas' : 'Notificações desativadas'"
+          />
         </div>
         <v-progress-linear
           bg-color="surface"

--- a/src/components/PomodoroFooter.vue
+++ b/src/components/PomodoroFooter.vue
@@ -144,6 +144,8 @@ const mode = ref<'work' | 'short' | 'long'>('work')
 const cycle = ref(1)
 const remaining = ref(DUR.work)
 const notificationPermission = ref(Notification.permission)
+const timerStartTime = ref<number | null>(null)
+const totalPausedTime = ref(0)
 let ticker: number | null = null
 
 // Audio for end sound
@@ -421,7 +423,7 @@ const notificationColor = computed(() =>
 function updatePageTitle() {
   if (running.value) {
     const modeText = mode.value === 'work'
-      ? '���� Foco'
+      ? '🍅 Foco'
       : mode.value === 'short'
         ? '☕ Pausa Curta'
         : '🛋️ Pausa Longa'


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses three key requirements:
1. Display notification permission status next to the timer
2. Update page title dynamically to reflect current timer state and remaining time
3. Fix timer continuation when page loses focus - ensure timer runs accurately regardless of browser tab focus

## Code changes

- **Notification indicator**: Added bell icon next to timer display showing notification permission status (green bell for enabled, orange bell-off for disabled)
- **Dynamic page title**: Implemented `updatePageTitle()` function that updates document title with current time and mode (e.g., "25:00 - 🍅 Foco | TrueDo")
- **Background timer fix**: Replaced interval-based countdown with timestamp-based calculation using `timerStartTime` and `totalPausedTime` tracking
- **Improved persistence**: Added timer state persistence to localStorage including start time and pause duration
- **Enhanced notifications**: Added browser notification support with permission handling and completion alerts
- **UI improvements**: Restructured timer display layout to accommodate notification icon with proper spacingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3ed3b9c35887496189b23c20b743bdd2/zen-haven)

👀 [Preview Link](https://3ed3b9c35887496189b23c20b743bdd2-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3ed3b9c35887496189b23c20b743bdd2</projectId>-->
<!--<branchName>zen-haven</branchName>-->